### PR TITLE
Export map as URL

### DIFF
--- a/map/index.html
+++ b/map/index.html
@@ -13,6 +13,7 @@
     ></script>
   </head>
   <body>
+    <input id="copy-to-clipboard" style="position:absolute;top:-2000px;left:-2000px">
     <div class="col-left">
       <button id="toggle-names" class="btn btn-primary d-block m-2">Show Tile Names</button>
       <button id="rotate" class="btn btn-primary d-block m-2">Rotate</button>
@@ -22,6 +23,7 @@
       <button onclick="$('#colour-modal').modal();" class="btn btn-primary d-block m-2">Clear Colours</button>
       <button id="import" class="btn btn-primary d-block m-2">Import</button>
       <button id="export" class="btn btn-primary d-block m-2">Export</button>
+      <button id="export-url" class="btn btn-primary d-block m-2">Export to URL</button>
       <input
         id="upload"
         type="file"

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -558,7 +558,85 @@ $(document).ready(function () {
     }
   }
 
+
+
+  function decode_config(encoded) {
+    init_config();
+    console.log(encoded);
+    encoded = BigInt(encoded);
+
+    let relics = [];
+    $("#select option").each(function () {
+      relics.push($(this).val());
+    });
+
+    const tile_coords = Object.keys(nodes);
+    for (let i = tile_coords.length - 1; i >= 0; i--) {
+      const tile = nodes[tile_coords[i]];
+      let colour = encoded % 8n;
+      encoded /= 8n;
+      if (colour === 7n) {
+        config[tile].colour = null;
+        config[tile].tile_type = "regular";
+      } else {
+        const col_idx = Number(colour) - 1;
+        config[tile].colour = col_idx >= 0 ? colours[col_idx] : null;
+
+        const image = encoded % 64n;
+        encoded /= 64n;
+        const relic_idx = Number(image) - 2;
+        if (relic_idx === -2) config[tile].tile_type = "regular";
+        else if (relic_idx === -1) config[tile].tile_type = "banner";
+        else {
+          config[tile].tile_type = "relic";
+          config[tile].relic = relics[relic_idx];
+        }
+      }
+    }
+  }
+
+  function encode_config(cfg) {
+    let relics = [];
+    $("#select option").each(function () {
+      relics.push($(this).val());
+    });
+
+    let encoded = 0n;
+    for (const tile of Object.keys(nodes)) {
+      const tile_data = cfg[nodes[tile]];
+      if (
+        tile_data === null ||
+        (tile_data.tile_type === "regular" && tile_data.colour === null)
+      ) {
+        encoded = encoded * 8n + 7n;
+      } else {
+        encoded *= 512n;
+
+        if (tile_data.tile_type === "banner") encoded += 8n;
+        else if (tile_data.tile_type === "relic") {
+          encoded +=
+            BigInt(relics.findIndex((c) => c === tile_data.relic) + 2) * 8n;
+        }
+
+        if (tile_data.colour !== null) {
+          encoded += BigInt(
+            colours.findIndex((c) => c === tile_data.colour) + 1
+          );
+        }
+      }
+    }
+    return encoded.toString();
+  }
+
   function onstart_config() {
+    const url_params = new URLSearchParams(window.location.search);
+    const param_config = url_params.get("config");
+
+    if(param_config) {
+      const rots = Number(url_params.get("rots") || "0");
+      decode_config(param_config);
+    }
+    
     if (config) {
       load_config();
     } else {
@@ -708,6 +786,16 @@ $(document).ready(function () {
     $("body").append(download);
     $("a")[0].click();
     $("a").remove();
+  });
+
+  $("#export-url").click(function () {
+    const data_encoded = encode_config(config);
+    const { protocol, hostname, pathname } = window.location;
+    const url = `${protocol}//${hostname}${pathname}?config=${data_encoded}&rots=${0}`;
+
+    const copy_text = $("#copy-to-clipboard");
+    copy_text.val(url).select();
+    document.execCommand("copy");
   });
 
   $(".tile").not(".immutable").click(function (e) {


### PR DESCRIPTION
Now that the map config has been revamped, here's a way to export the map as an URL. The encoding is:
- If a tile is empty, its value is `7`
- If it has contents a tile's encoding is:
  - The image is encoded in 6 bits:
    - If there's no image: `0` 
    - If it's a banner: `1`
    - If it's a relic: `2-63` (not all indexes are used)
  - The color is encoded in 3 bits:
    - If colorless: `0`
    - If it has a color: `1-6`

So a non empty tile is encoded as: `iiiiiiccc` while an empty one is `111`.
All the bits are concatenated and the resulting number is converted to Base 63.